### PR TITLE
Add live preview updating with form input

### DIFF
--- a/html_generator_form.html
+++ b/html_generator_form.html
@@ -210,6 +210,18 @@
             word-wrap: break-word;
         }
 
+        .live-preview-wrapper {
+            margin-top: 20px;
+        }
+
+        .live-preview-frame {
+            width: 100%;
+            height: 400px;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            display: block;
+        }
+
         @media (max-width: 768px) {
             .content {
                 grid-template-columns: 1fr;
@@ -435,19 +447,14 @@
                 <div id="previewArea" class="preview-area">
                     <div class="icon">📄</div>
                     <h3>HTML Preview</h3>
-                    <p>Fill out the form and click "Generate HTML" to see your page</p>
+                    <p>Fill out the form to see a live preview of your page</p>
                 </div>
             </div>
         </div>
     </div>
 
     <script>
-        function generateHTML() {
-            const form = document.getElementById('htmlForm');
-            const formData = new FormData(form);
-            
-            // Get the template HTML
-            const template = `<!DOCTYPE HTML>
+        const htmlTemplate = `<!DOCTYPE HTML>
 <html>
 
 <head>
@@ -781,8 +788,8 @@ https://www.google.com/maps/?cid=
 </body>
 </html>`;
 
-            // Create mapping of form fields to placeholders
-            const fieldMapping = {
+        // Mapping of form field names to template placeholders
+        const fieldMapping = {
                 'primaryKw': 'Primary KW',
                 'locationName': 'Location Name',
                 'gbLocationDescription': 'GB Location Description',
@@ -818,17 +825,55 @@ https://www.google.com/maps/?cid=
                 'idPageUrl': 'ID Page URL'
             };
 
-            // Replace placeholders with form data
-            let generatedHTML = template;
-            
+        const fieldNames = Object.keys(fieldMapping);
+        const htmlForm = document.getElementById('htmlForm');
+        const previewArea = document.getElementById('previewArea');
+        const defaultPreviewContent = previewArea.innerHTML;
+
+        window.generatedHTML = '';
+
+        htmlForm.addEventListener('input', handleLivePreview);
+        htmlForm.addEventListener('change', handleLivePreview);
+
+        updatePreview();
+
+        function handleLivePreview() {
+            updatePreview();
+        }
+
+        function generateHTML() {
+            updatePreview({ force: true });
+        }
+
+        function updatePreview({ force = false } = {}) {
+            const formData = new FormData(htmlForm);
+            const hasContent = force || fieldNames.some((name) => {
+                const value = formData.get(name);
+                return value && value.trim() !== '';
+            });
+
+            if (!hasContent) {
+                resetPreview();
+                return;
+            }
+
+            const generatedHTML = buildGeneratedHTML(formData);
+            renderPreview(generatedHTML);
+        }
+
+        function buildGeneratedHTML(formData) {
+            let generatedHTML = htmlTemplate;
+
             for (const [fieldName, placeholder] of Object.entries(fieldMapping)) {
                 const value = formData.get(fieldName) || '';
                 const regex = new RegExp(`\\[${placeholder}\\]`, 'g');
                 generatedHTML = generatedHTML.replace(regex, value);
             }
 
-            // Update preview area
-            const previewArea = document.getElementById('previewArea');
+            return generatedHTML;
+        }
+
+        function renderPreview(generatedHTML) {
             previewArea.className = 'preview-area has-content';
             previewArea.innerHTML = `
                 <h3>Generated HTML</h3>
@@ -836,10 +881,22 @@ https://www.google.com/maps/?cid=
                     <pre>${escapeHtml(generatedHTML)}</pre>
                 </div>
                 <button class="download-btn" onclick="downloadHTML()">Download HTML File</button>
+                <div class="live-preview-wrapper">
+                    <h3>Live Page Preview</h3>
+                    <iframe id="livePreviewFrame" class="live-preview-frame" title="Live HTML preview"></iframe>
+                </div>
             `;
-
-            // Store generated HTML for download
+            const livePreviewFrame = document.getElementById('livePreviewFrame');
+            if (livePreviewFrame) {
+                livePreviewFrame.srcdoc = generatedHTML;
+            }
             window.generatedHTML = generatedHTML;
+        }
+
+        function resetPreview() {
+            previewArea.className = 'preview-area';
+            previewArea.innerHTML = defaultPreviewContent;
+            window.generatedHTML = '';
         }
 
         function escapeHtml(unsafe) {


### PR DESCRIPTION
## Summary
- add styles and messaging updates for the preview panel
- refactor the generator script to share the template, listen for form input, and update both HTML and rendered previews in real time

## Testing
- not run (manual verification required)

------
https://chatgpt.com/codex/tasks/task_b_68c891b73b748331b345825a8a9678ba